### PR TITLE
KubeCF eirini integration - Make staging images full configurable

### DIFF
--- a/helm/eirini/templates/configmap.yaml
+++ b/helm/eirini/templates/configmap.yaml
@@ -17,20 +17,35 @@ data:
       {{- end }}
       registry_secret_name: {{ .Values.opi.registry_secret_name }}
       eirini_address: "https://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085"
+
+      {{- if .Values.opi.staging.downloader_image }}
+      downloader_image: "{{ .Values.opi.staging.downloader_image }}:{{ .Values.opi.staging.downloader_image_tag }}"
+      {{- else }}
       {{- if .Values.opi.staging.downloader_image_tag }}
       downloader_image: "eirini/recipe-downloader:{{ .Values.opi.staging.downloader_image_tag }}"
       {{- else }}
       downloader_image: eirini/recipe-downloader@{{ .Files.Get "versions/staging-downloader" }}
       {{- end }}
+      {{- end }}
+
+      {{- if .Values.opi.staging.executor_image }}
+      executor_image: "{{ .Values.opi.staging.executor_image }}:{{ .Values.opi.staging.executor_image_tag }}"
+      {{- else }}
       {{- if .Values.opi.staging.executor_image_tag }}
       executor_image: "eirini/recipe-executor:{{ .Values.opi.staging.executor_image_tag }}"
       {{- else }}
       executor_image: eirini/recipe-executor@{{ .Files.Get "versions/staging-executor" }}
       {{- end }}
+      {{- end }}
+
+      {{- if .Values.opi.staging.uploader_image }}
+      uploader_image: "{{ .Values.opi.staging.uploader_image }}:{{ .Values.opi.staging.uploader_image_tag }}"
+      {{- else }}
       {{- if .Values.opi.staging.uploader_image_tag }}
       uploader_image: "eirini/recipe-uploader:{{ .Values.opi.staging.uploader_image_tag }}"
       {{- else }}
       uploader_image: eirini/recipe-uploader@{{ .Files.Get "versions/staging-uploader" }}
+      {{- end }}
       {{- end }}
 
       cc_uploader_secret_name: {{ .Values.opi.staging.tls.cc_uploader.secretName }}


### PR DESCRIPTION
The staging images were only partially configurable (tags).
Extended to enable full configuration.
Existing logic is fallback when full configuration is not activated.

Untested as of right now.
