### PR TITLE
feat: helm: allow overriding opi.registry_address

### DIFF
--- a/helm/eirini/templates/configmap.yaml
+++ b/helm/eirini/templates/configmap.yaml
@@ -8,7 +8,9 @@ data:
   opi.yml: |
     opi:
       app_namespace: {{ .Values.opi.namespace }}
-      {{- if .Values.opi.use_registry_ingress }}
+      {{- if .Values.opi.staging.registry }}
+      registry_address: {{ .Values.opi.staging.registry }}
+      {{- else if .Values.opi.use_registry_ingress }}
       registry_address: "registry.{{ .Values.opi.ingress_endpoint }}:443"
       {{- else if .Values.services.loadbalanced }}
       registry_address: "registry.{{ .Values.env.DOMAIN }}:6666"
@@ -20,32 +22,26 @@ data:
 
       {{- if .Values.opi.staging.downloader_image }}
       downloader_image: "{{ .Values.opi.staging.downloader_image }}:{{ .Values.opi.staging.downloader_image_tag }}"
-      {{- else }}
-      {{- if .Values.opi.staging.downloader_image_tag }}
+      {{- else if .Values.opi.staging.downloader_image_tag }}
       downloader_image: "eirini/recipe-downloader:{{ .Values.opi.staging.downloader_image_tag }}"
       {{- else }}
       downloader_image: eirini/recipe-downloader@{{ .Files.Get "versions/staging-downloader" }}
       {{- end }}
-      {{- end }}
 
       {{- if .Values.opi.staging.executor_image }}
       executor_image: "{{ .Values.opi.staging.executor_image }}:{{ .Values.opi.staging.executor_image_tag }}"
-      {{- else }}
-      {{- if .Values.opi.staging.executor_image_tag }}
+      {{- else if .Values.opi.staging.executor_image_tag }}
       executor_image: "eirini/recipe-executor:{{ .Values.opi.staging.executor_image_tag }}"
       {{- else }}
       executor_image: eirini/recipe-executor@{{ .Files.Get "versions/staging-executor" }}
       {{- end }}
-      {{- end }}
 
       {{- if .Values.opi.staging.uploader_image }}
       uploader_image: "{{ .Values.opi.staging.uploader_image }}:{{ .Values.opi.staging.uploader_image_tag }}"
-      {{- else }}
-      {{- if .Values.opi.staging.uploader_image_tag }}
+      {{- else if .Values.opi.staging.uploader_image_tag }}
       uploader_image: "eirini/recipe-uploader:{{ .Values.opi.staging.uploader_image_tag }}"
       {{- else }}
       uploader_image: eirini/recipe-uploader@{{ .Files.Get "versions/staging-uploader" }}
-      {{- end }}
       {{- end }}
 
       cc_uploader_secret_name: {{ .Values.opi.staging.tls.cc_uploader.secretName }}

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -82,6 +82,8 @@ opi:
 
   staging:
     enable: true
+    # Override the registry endpoint, including host name and port.
+    registry: ~
     tls:
       client:
         secretName: "secrets-2.16.4-2"


### PR DESCRIPTION
This is meant as an escape hatch for more unusual configuration.

This is part of fixing https://github.com/cloudfoundry-incubator/kubecf/issues/794.