### PR TITLE
Make external services overridable.

### DIFF
--- a/helm/eirini/templates/configmap.yaml
+++ b/helm/eirini/templates/configmap.yaml
@@ -69,17 +69,29 @@ data:
       allow_run_image_as_root: false
   routing.yml: |
     app_namespace: {{ .Values.opi.namespace }}
-    nats_ip: "{{ .Values.opi.routing.nats.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local"
+    {{- $serviceName := .Values.opi.routing.nats.serviceName }}
+    {{- if contains "." $serviceName | not }}
+    {{- $serviceName = printf "%s.%s.svc" $serviceName .Release.Namespace }}
+    {{- end }}
+    nats_ip: {{ $serviceName }}
     nats_port: 4222
   metrics.yml: |
     app_namespace: {{ .Values.opi.namespace }}
-    loggregator_address: "{{ .Values.opi.logs.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:8082"
+    {{- $serviceName := .Values.opi.logs.serviceName }}
+    {{- if contains "." $serviceName | not }}
+    {{- $serviceName = printf "%s.%s.svc" $serviceName .Release.Namespace }}
+    {{- end }}
+    loggregator_address: "{{ $serviceName }}:8082"
     loggergator_cert_path: "/etc/eirini/secrets/doppler.crt"
     loggregator_key_path: "/etc/eirini/secrets/doppler.key"
     loggregator_ca_path: "/etc/eirini/secrets/doppler.ca"
   events.yml: |
     app_namespace: {{ .Values.opi.namespace }}
-    cc_internal_api: "https://{{ .Values.opi.cc_api.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9023"
+    {{- $serviceName := .Values.opi.cc_api.serviceName }}
+    {{- if contains "." $serviceName | not }}
+    {{- $serviceName = printf "%s.%s.svc" $serviceName .Release.Namespace }}
+    {{- end }}
+    cc_internal_api: "https://{{ $serviceName }}:9023"
     cc_cert_path: "/etc/eirini/secrets/cc.crt"
     cc_key_path: "/etc/eirini/secrets/cc.key"
     cc_ca_path: "/etc/eirini/secrets/cc.ca"

--- a/helm/eirini/templates/configmap.yaml
+++ b/helm/eirini/templates/configmap.yaml
@@ -18,7 +18,8 @@ data:
       registry_address: "registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666"
       {{- end }}
       registry_secret_name: {{ .Values.opi.registry_secret_name }}
-      eirini_address: "https://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085"
+      {{- $default_eirini_address := printf "https://eirini-opi.%s.svc:8085" .Release.Namespace }}
+      eirini_address: {{ default $default_eirini_address .Values.opi.eirini_address }}
 
       {{- if .Values.opi.staging.downloader_image }}
       downloader_image: "{{ .Values.opi.staging.downloader_image }}:{{ .Values.opi.staging.downloader_image_tag }}"

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -12,6 +12,7 @@ opi:
   version: 0.0.0
 
   cc_api:
+    # The service that the CC API listens on; may be a FQDN instead.
     serviceName: "api"
 
   tls:
@@ -44,6 +45,7 @@ opi:
 
   logs:
     enable: true
+    # The service that doppler is listening on; may be a FQDN instead.
     serviceName: "doppler-doppler"
     tls:
       client:
@@ -74,6 +76,7 @@ opi:
     nats:
       secretName: "secrets-2.16.4-2"
       passwordPath: "nats-password"
+      # The service that NATS listens on; may be a FQDN instead.
       serviceName: "nats-nats"
 
   secretSmuggler:


### PR DESCRIPTION
This makes the various external service names (api, doppler, nats) accept FQDNs in addition to just service names; also, drop the `.cluster.local` default suffix, as they are not always correct on all kubernetes deployments (but the DNS search path should handle things correctly).  Also make the `eirini_address` customizable (as a complete override, not as a name).

Existing tests should cover the changes, as this just adds configuration knobs and the defaults are equivalent.
